### PR TITLE
V3 spec updates 20200918

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,44 +573,44 @@ array([[12, 13, 14, 15, 16],
 Read data previously copied to GCS (temporarily disabled):
 
 ```python
-#>>> h = zarrita.get_hierarchy('gs://zarr-demo/v3/test.zr3', token='anon')
-#>>> h
-#<Hierarchy at gs://zarr-demo/v3/test.zr3>
-#>>> sorted(h)
-#['/', '/arthur', '/arthur/dent', '/marvin', '/marvin/android', '/marvin/paranoid', '/tricia', '/tricia/mcmillan']
-#>>> h.get_children('/')  # doctest: +NORMALIZE_WHITESPACE
-#{'arthur': 'implicit_group', 
-# 'marvin': 'explicit_group', 
-# 'tricia': 'implicit_group'}
-#>>> h.get_children('/tricia')
-#{'mcmillan': 'explicit_group'}
-#>>> h.get_children('/tricia/mcmillan')
-#{}
-#>>> h.get_children('/arthur')
-#{'dent': 'array'}
-#>>> h['/']
-#<Group / (implied)>
-#>>> h['/tricia']
-#<Group /tricia (implied)>
-#>>> g = h['/tricia/mcmillan']
-#>>> g
-#<Group /tricia/mcmillan>
-#>>> g.attrs
-#{'heart': 'gold', 'improbability': 'infinite'}
-#>>> a = h['/arthur/dent']
-#>>> a
-#<Array /arthur/dent>
-#>>> a.shape
-#(5, 10)
-#>>> a.dtype
-#dtype('int32')
-#>>> a.attrs
-#{'question': 'life', 'answer': 42}
-#>>> a[:]
-#array([[ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9],
-#       [10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
-#       [20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
-#       [30, 31, 32, 33, 34, 35, 36, 37, 38, 39],
-#       [40, 41, 42, 43, 44, 45, 46, 47, 48, 49]], dtype=int32)
-#
+>>> h = zarrita.get_hierarchy('gs://zarr-demo/v3/test.zr3', token='anon')
+>>> h
+<Hierarchy at gs://zarr-demo/v3/test.zr3>
+>>> sorted(h)
+['/', '/arthur', '/arthur/dent', '/marvin', '/marvin/android', '/marvin/paranoid', '/tricia', '/tricia/mcmillan']
+>>> h.get_children('/')  # doctest: +NORMALIZE_WHITESPACE
+{'arthur': 'implicit_group', 
+ 'marvin': 'explicit_group', 
+ 'tricia': 'implicit_group'}
+>>> h.get_children('/tricia')
+{'mcmillan': 'explicit_group'}
+>>> h.get_children('/tricia/mcmillan')
+{}
+>>> h.get_children('/arthur')
+{'dent': 'array'}
+>>> h['/']
+<Group / (implied)>
+>>> h['/tricia']
+<Group /tricia (implied)>
+>>> g = h['/tricia/mcmillan']
+>>> g
+<Group /tricia/mcmillan>
+>>> g.attrs
+{'heart': 'gold', 'improbability': 'infinite'}
+>>> a = h['/arthur/dent']
+>>> a
+<Array /arthur/dent>
+>>> a.shape
+(5, 10)
+>>> a.dtype
+dtype('int32')
+>>> a.attrs
+{'question': 'life', 'answer': 42}
+>>> a[:]
+array([[ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9],
+       [10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
+       [20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
+       [30, 31, 32, 33, 34, 35, 36, 37, 38, 39],
+       [40, 41, 42, 43, 44, 45, 46, 47, 48, 49]], dtype=int32)
+
 ```

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ test.zr3
 >>> cat('test.zr3/zarr.json')
 {
     "zarr_format": "https://purl.org/zarr/spec/protocol/core/3.0",
-    "metadata_encoding": "application/json",
+    "metadata_encoding": "https://purl.org/zarr/spec/protocol/core/3.0",
     "extensions": []
 }
 
@@ -559,47 +559,47 @@ array([[12, 13, 14, 15, 16],
 
 ## Use cloud storage
  
-Read data previously copied to GCS:
+Read data previously copied to GCS (temporarily disabled):
 
 ```python
->>> h = zarrita.get_hierarchy('gs://zarr-demo/v3/test.zr3', token='anon')
->>> h
-<Hierarchy at gs://zarr-demo/v3/test.zr3>
->>> sorted(h)
-['/', '/arthur', '/arthur/dent', '/marvin', '/marvin/android', '/marvin/paranoid', '/tricia', '/tricia/mcmillan']
->>> h.get_children('/')  # doctest: +NORMALIZE_WHITESPACE
-{'arthur': 'implicit_group', 
- 'marvin': 'explicit_group', 
- 'tricia': 'implicit_group'}
->>> h.get_children('/tricia')
-{'mcmillan': 'explicit_group'}
->>> h.get_children('/tricia/mcmillan')
-{}
->>> h.get_children('/arthur')
-{'dent': 'array'}
->>> h['/']
-<Group / (implied)>
->>> h['/tricia']
-<Group /tricia (implied)>
->>> g = h['/tricia/mcmillan']
->>> g
-<Group /tricia/mcmillan>
->>> g.attrs
-{'heart': 'gold', 'improbability': 'infinite'}
->>> a = h['/arthur/dent']
->>> a
-<Array /arthur/dent>
->>> a.shape
-(5, 10)
->>> a.dtype
-dtype('int32')
->>> a.attrs
-{'question': 'life', 'answer': 42}
->>> a[:]
-array([[ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9],
-       [10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
-       [20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
-       [30, 31, 32, 33, 34, 35, 36, 37, 38, 39],
-       [40, 41, 42, 43, 44, 45, 46, 47, 48, 49]], dtype=int32)
-
+#>>> h = zarrita.get_hierarchy('gs://zarr-demo/v3/test.zr3', token='anon')
+#>>> h
+#<Hierarchy at gs://zarr-demo/v3/test.zr3>
+#>>> sorted(h)
+#['/', '/arthur', '/arthur/dent', '/marvin', '/marvin/android', '/marvin/paranoid', '/tricia', '/tricia/mcmillan']
+#>>> h.get_children('/')  # doctest: +NORMALIZE_WHITESPACE
+#{'arthur': 'implicit_group', 
+# 'marvin': 'explicit_group', 
+# 'tricia': 'implicit_group'}
+#>>> h.get_children('/tricia')
+#{'mcmillan': 'explicit_group'}
+#>>> h.get_children('/tricia/mcmillan')
+#{}
+#>>> h.get_children('/arthur')
+#{'dent': 'array'}
+#>>> h['/']
+#<Group / (implied)>
+#>>> h['/tricia']
+#<Group /tricia (implied)>
+#>>> g = h['/tricia/mcmillan']
+#>>> g
+#<Group /tricia/mcmillan>
+#>>> g.attrs
+#{'heart': 'gold', 'improbability': 'infinite'}
+#>>> a = h['/arthur/dent']
+#>>> a
+#<Array /arthur/dent>
+#>>> a.shape
+#(5, 10)
+#>>> a.dtype
+#dtype('int32')
+#>>> a.attrs
+#{'question': 'life', 'answer': 42}
+#>>> a[:]
+#array([[ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9],
+#       [10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
+#       [20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
+#       [30, 31, 32, 33, 34, 35, 36, 37, 38, 39],
+#       [40, 41, 42, 43, 44, 45, 46, 47, 48, 49]], dtype=int32)
+#
 ```

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ test.zr3
         "chunk_shape": [
             2,
             5
-        ]
+        ],
+        "separator": "/"
     },
     "chunk_memory_layout": "C",
     "compressor": {
@@ -423,10 +424,12 @@ array([[42, 42, 42, 42, 42, 42, 42, 42, 42, 42],
 >>> tree('test.zr3', '-n', '--noreport')  # doctest: +NORMALIZE_WHITESPACE
 test.zr3
 ├── data
-│   └── arthur
-│       └── dent
-│           ├── 0.0
-│           └── 0.1
+│   └── root
+│       └── arthur
+│           └── dent
+│               └── c0
+│                   ├── 0
+│                   └── 1
 ├── meta
 │   └── root
 │       ├── arthur
@@ -448,12 +451,16 @@ array([[42, 42, 42, 42, 42, 42, 42, 42, 42, 42],
 >>> tree('test.zr3', '-n', '--noreport')  # doctest: +NORMALIZE_WHITESPACE
 test.zr3
 ├── data
-│   └── arthur
-│       └── dent
-│           ├── 0.0
-│           ├── 0.1
-│           ├── 1.0
-│           └── 2.0
+│   └── root
+│       └── arthur
+│           └── dent
+│               ├── c0
+│               │   ├── 0
+│               │   └── 1
+│               ├── c1
+│               │   └── 0
+│               └── c2
+│                   └── 0
 ├── meta
 │   └── root
 │       ├── arthur
@@ -475,14 +482,18 @@ array([[42, 42, 42, 42, 42, 42, 42, 42, 42, 42],
 >>> tree('test.zr3', '-n', '--noreport')  # doctest: +NORMALIZE_WHITESPACE
 test.zr3
 ├── data
-│   └── arthur
-│       └── dent
-│           ├── 0.0
-│           ├── 0.1
-│           ├── 1.0
-│           ├── 1.1
-│           ├── 2.0
-│           └── 2.1
+│   └── root
+│       └── arthur
+│           └── dent
+│               ├── c0
+│               │   ├── 0
+│               │   └── 1
+│               ├── c1
+│               │   ├── 0
+│               │   └── 1
+│               └── c2
+│                   ├── 0
+│                   └── 1
 ├── meta
 │   └── root
 │       ├── arthur

--- a/zarrita.py
+++ b/zarrita.py
@@ -6,7 +6,6 @@ import itertools
 import math
 from collections.abc import Mapping, MutableMapping
 from typing import Iterator, Union, Optional, Tuple, Any, List, Dict, NamedTuple
-from operator import itemgetter
 
 # third-party dependencies
 
@@ -52,7 +51,7 @@ def create_hierarchy(store: Union[str, Store], **storage_options) -> Hierarchy:
     # create entry point metadata document
     meta: Dict[str, Any] = dict(
         zarr_format='https://purl.org/zarr/spec/protocol/core/3.0',
-        metadata_encoding='application/json',
+        metadata_encoding='https://purl.org/zarr/spec/protocol/core/3.0',
         extensions=[],
     )
 
@@ -88,7 +87,7 @@ def get_hierarchy(store: Union[str, Store], **storage_options) -> Hierarchy:
 
     # check metadata encoding
     metadata_encoding = meta['metadata_encoding']
-    if metadata_encoding != 'application/json':
+    if metadata_encoding != 'https://purl.org/zarr/spec/protocol/core/3.0':
         raise NotImplementedError
 
     # check extensions

--- a/zarrita.py
+++ b/zarrita.py
@@ -228,6 +228,7 @@ class Hierarchy(Mapping):
                      shape: Tuple[int],
                      dtype: Any,
                      chunk_shape: Tuple[int],
+                     chunk_separator: str = '/',
                      compressor: Optional[Codec] = None,
                      fill_value: Any = None,
                      attrs: Optional[Mapping] = None) -> Array:
@@ -253,6 +254,7 @@ class Hierarchy(Mapping):
             chunk_grid=dict(
                 type='regular',
                 chunk_shape=chunk_shape,
+                separator=chunk_separator,
             ),
             chunk_memory_layout='C',
             compressor=_encode_codec_metadata(compressor),
@@ -273,8 +275,8 @@ class Hierarchy(Mapping):
         # instantiate array
         array = Array(store=self.store, path=path, owner=self,
                       shape=shape, dtype=dtype, chunk_shape=chunk_shape,
-                      compressor=compressor, fill_value=fill_value,
-                      attrs=attrs)
+                      chunk_separator=chunk_separator, compressor=compressor,
+                      fill_value=fill_value, attrs=attrs)
 
         return array
 
@@ -301,6 +303,7 @@ class Hierarchy(Mapping):
             raise NotImplementedError
         chunk_shape = tuple(chunk_grid['chunk_shape'])
         _check_chunk_shape(chunk_shape, shape)
+        chunk_separator = chunk_grid['separator']
         chunk_memory_layout = meta['chunk_memory_layout']
         if chunk_memory_layout != 'C':
             raise NotImplementedError
@@ -313,7 +316,8 @@ class Hierarchy(Mapping):
 
         # instantiate array
         a = Array(store=self.store, path=path, owner=self, shape=shape,
-                  dtype=dtype, chunk_shape=chunk_shape, compressor=compressor,
+                  dtype=dtype, chunk_shape=chunk_shape,
+                  chunk_separator=chunk_separator, compressor=compressor,
                   fill_value=fill_value, attrs=attrs)
 
         return a
@@ -555,6 +559,7 @@ class Array(Node):
                  shape: Tuple[int, ...],
                  dtype: Any,
                  chunk_shape: Tuple[int, ...],
+                 chunk_separator: str,
                  compressor: Optional[Codec],
                  fill_value: Any = None,
                  attrs: Optional[Mapping] = None):
@@ -562,6 +567,7 @@ class Array(Node):
         self.shape = shape
         self.dtype = dtype
         self.chunk_shape = chunk_shape
+        self.chunk_separator = chunk_separator
         self.compressor = compressor
         self.fill_value = fill_value
         self.attrs = attrs
@@ -618,13 +624,9 @@ class Array(Node):
             out[out_selection] = tmp
 
     def _chunk_key(self, chunk_coords):
-        suffix = '.'.join(map(str, chunk_coords))
-        if self.path == '/':
-            # special case array as root node
-            key = f'data/{suffix}'
-        else:
-            key = f'data{self.path}/{suffix}'
-        return key
+        chunk_identifier = 'c' + self.chunk_separator.join(map(str, chunk_coords))
+        chunk_key = f'data/root{self.path}/{chunk_identifier}'
+        return chunk_key
 
     def _decode_chunk(self, encoded_data):
 


### PR DESCRIPTION
* [x] Change metadata encoding URI
* [x] Configurable chunk key separator, defaulting to '/' (resolves #13)
* [x] Change chunk key path to begin "data/root" to mirror metadata key paths
* [x] Update cloud example data and reinstate cloud doctest
 