### PR TITLE
Don't write compressor if None

### DIFF
--- a/zarrita.py
+++ b/zarrita.py
@@ -263,6 +263,9 @@ class Hierarchy(Mapping):
             attributes=attrs,
         )
 
+        if compressor is None:
+            del meta['compressor']
+
         # serialise and store metadata document
         meta_doc = _json_encode_object(meta)
         if path == '/':


### PR DESCRIPTION
According to the latest spec, when there is no compressor it must not even be written to the array metadata JSON file.